### PR TITLE
localStorage isnt available at server and in incognito mode

### DIFF
--- a/packages/features/ee/payments/components/PaymentPage.tsx
+++ b/packages/features/ee/payments/components/PaymentPage.tsx
@@ -12,6 +12,7 @@ import { WEBSITE_URL } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import useTheme from "@calcom/lib/hooks/useTheme";
 import { getIs24hClockFromLocalStorage, isBrowserLocale24h } from "@calcom/lib/timeFormat";
+import { localStorage } from "@calcom/lib/webstorage";
 import { Icon } from "@calcom/ui/Icon";
 
 import type { PaymentPageProps } from "../pages/payment";
@@ -21,11 +22,14 @@ const PaymentPage: FC<PaymentPageProps> = (props) => {
   const { t } = useLocale();
   const [is24h, setIs24h] = useState(isBrowserLocale24h());
   const [date, setDate] = useState(dayjs.utc(props.booking.startTime));
+  const [timezone, setTimezone] = useState<string | null>(null);
   useTheme(props.profile.theme);
   const isEmbed = useIsEmbed();
   useEffect(() => {
     let embedIframeWidth = 0;
-    setDate(date.tz(localStorage.getItem("timeOption.preferredTimeZone") || dayjs.tz.guess()));
+    const _timezone = localStorage.getItem("timeOption.preferredTimeZone") || dayjs.tz.guess();
+    setTimezone(_timezone);
+    setDate(date.tz(_timezone));
     setIs24h(!!getIs24hClockFromLocalStorage());
     if (isEmbed) {
       requestAnimationFrame(function fixStripeIframe() {
@@ -95,9 +99,7 @@ const PaymentPage: FC<PaymentPageProps> = (props) => {
                         {date.format("dddd, DD MMMM YYYY")}
                         <br />
                         {date.format(is24h ? "H:mm" : "h:mma")} - {props.eventType.length} mins{" "}
-                        <span className="text-gray-500">
-                          ({localStorage.getItem("timeOption.preferredTimeZone") || dayjs.tz.guess()})
-                        </span>
+                        <span className="text-gray-500">({timezone})</span>
                       </div>
                       {props.booking.location && (
                         <>


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)
- Fixes CAL-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/calcom/cal.com/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings


---

<!-- kody-pr-summary:start -->
Refactors the `PaymentPage` component to improve how the preferred timezone is handled and displayed.

Key changes include:
- Importing `localStorage` from `@calcom/lib/webstorage` to provide a more robust way to access local storage, especially in environments where it might not be available (e.g., server-side rendering or incognito mode).
- Introducing a new state variable `timezone` to store the user's preferred timezone after it's retrieved from local storage or guessed.
- Updating the date formatting and display to use this new `timezone` state, ensuring consistency and preventing direct `localStorage` access during rendering.

This change enhances the reliability of the payment page by gracefully handling scenarios where `localStorage` might be inaccessible and ensures the displayed timezone is consistent with the one used for date calculations.
<!-- kody-pr-summary:end -->

---

<!-- kody-pr-summary:start -->
This pull request addresses issues where `localStorage` might not be available, such as during server-side rendering or in incognito browser modes.

Key changes include:
*   **Robust `localStorage` access:** Replaces direct `localStorage` calls with an imported wrapper from `@calcom/lib/webstorage` to handle environments where `localStorage` might be inaccessible.
*   **Improved timezone handling:** The preferred timezone is now retrieved once in a `useEffect` hook, stored in the component's state, and then consistently used for both setting the booking date and displaying the timezone to the user. This prevents redundant `localStorage` lookups and ensures the displayed timezone is always based on the initially determined value.
<!-- kody-pr-summary:end -->

---

<!-- kody-pr-summary:start -->
Refactors the `PaymentPage` component to improve how the preferred timezone is handled and displayed.

Key changes include:
- Importing `localStorage` from `@calcom/lib/webstorage` to provide a more robust way to access local storage, especially in environments where it might not be available (e.g., server-side rendering or incognito mode).
- Introducing a new state variable `timezone` to store the user's preferred timezone after it's retrieved from local storage or guessed.
- Updating the date formatting and display to use this new `timezone` state, ensuring consistency and preventing direct `localStorage` access during rendering.

This change enhances the reliability of the payment page by gracefully handling scenarios where `localStorage` might be inaccessible and ensures the displayed timezone is consistent with the one used for date calculations.
<!-- kody-pr-summary:end -->