### PR TITLE
fix/25589-phone-label

### DIFF
--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/transformers/api-to-internal/api-to-internal.spec.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/transformers/api-to-internal/api-to-internal.spec.ts
@@ -236,7 +236,43 @@ describe("transformBookingFieldsApiToInternal", () => {
       {
         name: bookingField.slug,
         type: bookingField.type,
-        label: bookingField.label,
+        label: "Your phone number",
+        sources: [
+          {
+            id: "user",
+            type: "user",
+            label: "User",
+            fieldRequired: true,
+          },
+        ],
+        editable: "user",
+        required: bookingField.required,
+        placeholder: bookingField.placeholder,
+        disableOnPrefill: false,
+        hidden: false,
+      },
+    ];
+
+    const result = transformBookingFieldsApiToInternal(input);
+
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it("should transform phone field without label (uses empty string fallback)", () => {
+    const bookingField: InputBookingField_2024_06_14 = {
+      type: "phone",
+      slug: "phone",
+      required: true,
+      placeholder: "123456789",
+    };
+
+    const input: InputBookingField_2024_06_14[] = [bookingField];
+
+    const expectedOutput: CustomField[] = [
+      {
+        name: bookingField.slug,
+        type: bookingField.type,
+        label: "",
         sources: [
           {
             id: "user",

--- a/apps/api/v2/src/ee/event-types/event-types_2024_06_14/transformers/api-to-internal/booking-fields.ts
+++ b/apps/api/v2/src/ee/event-types/event-types_2024_06_14/transformers/api-to-internal/booking-fields.ts
@@ -237,7 +237,7 @@ function getBaseProperties(field: InputBookingField): CustomField | SystemField 
   return {
     name: field.slug,
     type: field.type,
-    label: "label" in field ? field.label : "",
+    label: "label" in field && field.label ? field.label : "",
     sources: [
       {
         id: "user",

--- a/packages/platform/types/event-types/event-types_2024_06_14/inputs/booking-fields.input.ts
+++ b/packages/platform/types/event-types/event-types_2024_06_14/inputs/booking-fields.input.ts
@@ -342,8 +342,11 @@ export class PhoneFieldInput_2024_06_14 {
   slug!: string;
 
   @IsString()
-  @DocsProperty()
-  label!: string;
+  @IsOptional()
+  @DocsPropertyOptional({
+    description: "Label for the phone field. If not provided, the default translated label will be used.",
+  })
+  label?: string;
 
   @IsBoolean()
   @DocsProperty()
@@ -351,7 +354,7 @@ export class PhoneFieldInput_2024_06_14 {
 
   @IsString()
   @IsOptional()
-  @DocsProperty()
+  @DocsPropertyOptional()
   placeholder?: string;
 
   @IsBoolean()
@@ -367,7 +370,7 @@ export class PhoneFieldInput_2024_06_14 {
 
   @IsBoolean()
   @IsOptional()
-  @DocsProperty({
+  @DocsPropertyOptional({
     description:
       "If true show under event type settings but don't show this booking field in the Booker. If false show in both.",
   })


### PR DESCRIPTION
PR criada automaticamente.

Source: upstream/fix/25589-phone-label


---

<!-- kody-pr-summary:start -->
This pull request addresses an issue with phone booking field labels by making the `label` property optional in the API input and ensuring proper handling during data transformation.

Key changes include:
*   **Optional Phone Field Label:** The `label` property for `PhoneFieldInput_2024_06_14` is now optional in the API schema. If not provided, the system is intended to use a default translated label.
*   **Improved Transformation Logic:** The API transformer now correctly handles cases where the `label` for a booking field is missing or explicitly an empty string, defaulting it to an empty string internally.
*   **Updated Documentation:** API documentation for the `label`, `placeholder`, and `hidden` properties of phone fields has been updated to reflect their optional nature.
*   **New Test Case:** A new test case was added to verify the transformation of phone fields when the `label` is not provided, ensuring it defaults to an empty string.
<!-- kody-pr-summary:end -->