### PR TITLE
perf/teams-page-client-caching

### DIFF
--- a/apps/web/app/(use-page-wrapper)/(main-nav)/availability/actions.ts
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/availability/actions.ts
@@ -1,7 +1,9 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { revalidateTag } from "next/cache";
+
+import { AVAILABILITY_CACHE_TAG } from "./cache";
 
 export async function revalidateAvailabilityList() {
-  revalidatePath("/availability");
+  revalidateTag(AVAILABILITY_CACHE_TAG, "max");
 }

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/availability/cache.ts
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/availability/cache.ts
@@ -1,0 +1,1 @@
+export const AVAILABILITY_CACHE_TAG = "viewer.availability.list";

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/availability/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/availability/page.tsx
@@ -1,7 +1,7 @@
 import { createRouterCaller, getTRPCContext } from "app/_trpc/context";
 import type { PageProps, ReadonlyHeaders, ReadonlyRequestCookies } from "app/_types";
 import { _generateMetadata, getTranslate } from "app/_utils";
-import { unstable_cache, cacheLife, cacheTag } from "next/cache";
+import { unstable_cache } from "next/cache";
 import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 
@@ -44,10 +44,6 @@ const getCachedAvailabilities = unstable_cache(
 );
 
 const Page = async ({ searchParams: _searchParams }: PageProps) => {
-  "use cache: private";
-  cacheLife({ stale: 30 });
-  cacheTag(AVAILABILITY_CACHE_TAG);
-
   const searchParams = await _searchParams;
   const t = await getTranslate();
   const _headers = await headers();

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/actions.ts
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/actions.ts
@@ -1,7 +1,9 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { revalidateTag } from "next/cache";
+
+import { EVENT_TYPES_CACHE_TAG } from "./cache";
 
 export async function revalidateEventTypesList() {
-  revalidatePath("/event-types");
+  revalidateTag(EVENT_TYPES_CACHE_TAG, "max");
 }

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/cache.ts
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/cache.ts
@@ -1,0 +1,1 @@
+export const EVENT_TYPES_CACHE_TAG = "viewer.eventTypes.getUserEventGroups";

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/page.tsx
@@ -11,7 +11,7 @@ import type {
   ReadonlyRequestCookies,
 } from "app/_types";
 import { _generateMetadata } from "app/_utils";
-import { unstable_cache, cacheLife, cacheTag } from "next/cache";
+import { unstable_cache } from "next/cache";
 import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 import type { ReactElement } from "react";
@@ -49,10 +49,6 @@ const getCachedEventGroups: (
   );
 
 const Page = async ({ searchParams }: PageProps): Promise<ReactElement> => {
-  "use cache: private";
-  cacheLife({ stale: 30 });
-  cacheTag(EVENT_TYPES_CACHE_TAG);
-
   const _searchParams = await searchParams;
   const _headers = await headers();
   const _cookies = await cookies();

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/event-types/page.tsx
@@ -11,12 +11,13 @@ import type {
   ReadonlyRequestCookies,
 } from "app/_types";
 import { _generateMetadata } from "app/_utils";
-import { unstable_cache } from "next/cache";
+import { unstable_cache, cacheLife, cacheTag } from "next/cache";
 import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 import type { ReactElement } from "react";
 
 import { EventTypesWrapper } from "./EventTypesWrapper";
+import { EVENT_TYPES_CACHE_TAG } from "./cache";
 
 const getCachedEventGroups: (
   headers: ReadonlyHeaders,
@@ -43,11 +44,15 @@ const getCachedEventGroups: (
       );
       return await eventTypesCaller.getUserEventGroups({ filters });
     },
-    ["viewer.eventTypes.getUserEventGroups"],
-    { revalidate: 3600 } // seconds
+    [EVENT_TYPES_CACHE_TAG],
+    { revalidate: 3600, tags: [EVENT_TYPES_CACHE_TAG] }
   );
 
 const Page = async ({ searchParams }: PageProps): Promise<ReactElement> => {
+  "use cache: private";
+  cacheLife({ stale: 30 });
+  cacheTag(EVENT_TYPES_CACHE_TAG);
+
   const _searchParams = await searchParams;
   const _headers = await headers();
   const _cookies = await cookies();

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/teams/actions.ts
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/teams/actions.ts
@@ -2,6 +2,8 @@
 
 import { revalidateTag } from "next/cache";
 
+import { TEAMS_CACHE_TAG } from "./cache";
+
 export async function revalidateTeamsList() {
-  revalidateTag("viewer.teams.list", "max");
+  revalidateTag(TEAMS_CACHE_TAG, "max");
 }

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/teams/cache.ts
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/teams/cache.ts
@@ -1,0 +1,1 @@
+export const TEAMS_CACHE_TAG = "viewer.teams.list";

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/teams/server-page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/teams/server-page.tsx
@@ -12,6 +12,7 @@ import { MembershipRole } from "@calcom/prisma/enums";
 import { TeamsListing } from "~/ee/teams/components/TeamsListing";
 
 import { TeamsCTA } from "./CTA";
+import { TEAMS_CACHE_TAG } from "./cache";
 
 const getCachedTeams = unstable_cache(
   async (userId: number) => {
@@ -22,7 +23,7 @@ const getCachedTeams = unstable_cache(
     });
   },
   undefined,
-  { revalidate: 3600, tags: ["viewer.teams.list"] } // Cache for 1 hour
+  { revalidate: 3600, tags: [TEAMS_CACHE_TAG] }
 );
 
 export const ServerTeamsListing = async ({
@@ -34,7 +35,7 @@ export const ServerTeamsListing = async ({
 }) => {
   "use cache: private";
   cacheLife({ stale: 30 });
-  cacheTag("viewer.teams.list");
+  cacheTag(TEAMS_CACHE_TAG);
   const token = Array.isArray(searchParams?.token) ? searchParams.token[0] : searchParams?.token;
   const autoAccept = Array.isArray(searchParams?.autoAccept)
     ? searchParams.autoAccept[0]

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/teams/server-page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/teams/server-page.tsx
@@ -1,6 +1,6 @@
 import type { SearchParams } from "app/_types";
 import type { Session } from "next-auth";
-import { unstable_cache, cacheLife, cacheTag } from "next/cache";
+import { unstable_cache } from "next/cache";
 
 import { TeamRepository } from "@calcom/features/ee/teams/repositories/TeamRepository";
 import { TeamService } from "@calcom/features/ee/teams/services/teamService";
@@ -33,9 +33,6 @@ export const ServerTeamsListing = async ({
   searchParams: SearchParams;
   session: Session;
 }) => {
-  "use cache: private";
-  cacheLife({ stale: 30 });
-  cacheTag(TEAMS_CACHE_TAG);
   const token = Array.isArray(searchParams?.token) ? searchParams.token[0] : searchParams?.token;
   const autoAccept = Array.isArray(searchParams?.autoAccept)
     ? searchParams.autoAccept[0]

--- a/apps/web/app/(use-page-wrapper)/(main-nav)/teams/server-page.tsx
+++ b/apps/web/app/(use-page-wrapper)/(main-nav)/teams/server-page.tsx
@@ -1,6 +1,6 @@
 import type { SearchParams } from "app/_types";
 import type { Session } from "next-auth";
-import { unstable_cache } from "next/cache";
+import { unstable_cache, cacheLife, cacheTag } from "next/cache";
 
 import { TeamRepository } from "@calcom/features/ee/teams/repositories/TeamRepository";
 import { TeamService } from "@calcom/features/ee/teams/services/teamService";
@@ -32,6 +32,9 @@ export const ServerTeamsListing = async ({
   searchParams: SearchParams;
   session: Session;
 }) => {
+  "use cache: private";
+  cacheLife({ stale: 30 });
+  cacheTag("viewer.teams.list");
   const token = Array.isArray(searchParams?.token) ? searchParams.token[0] : searchParams?.token;
   const autoAccept = Array.isArray(searchParams?.autoAccept)
     ? searchParams.autoAccept[0]

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/api-keys/actions.ts
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/api-keys/actions.ts
@@ -2,6 +2,8 @@
 
 import { revalidateTag } from "next/cache";
 
+import { API_KEYS_CACHE_TAG } from "./cache";
+
 export async function revalidateApiKeysList() {
-  revalidateTag("viewer.apiKeys.list", "max");
+  revalidateTag(API_KEYS_CACHE_TAG, "max");
 }

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/api-keys/cache.ts
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/api-keys/cache.ts
@@ -1,0 +1,1 @@
+export const API_KEYS_CACHE_TAG = "viewer.apiKeys.list";

--- a/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/api-keys/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(settings-layout)/developer/api-keys/page.tsx
@@ -1,5 +1,5 @@
 import { _generateMetadata } from "app/_utils";
-import { unstable_cache, cacheLife, cacheTag } from "next/cache";
+import { unstable_cache } from "next/cache";
 import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 
@@ -32,10 +32,6 @@ const getCachedApiKeys = unstable_cache(
 );
 
 const Page = async () => {
-  "use cache: private";
-  cacheLife({ stale: 30 });
-  cacheTag(API_KEYS_CACHE_TAG);
-
   const session = await getServerSession({ req: buildLegacyRequest(await headers(), await cookies()) });
 
   if (!session) {

--- a/apps/web/app/(use-page-wrapper)/settings/organizations/(org-user-only)/members/actions.ts
+++ b/apps/web/app/(use-page-wrapper)/settings/organizations/(org-user-only)/members/actions.ts
@@ -2,6 +2,12 @@
 
 import { revalidateTag } from "next/cache";
 
+import { ORG_ATTRIBUTES_CACHE_TAG, ORG_ROLES_CACHE_TAG } from "./cache";
+
 export async function revalidateAttributesList() {
-  revalidateTag("viewer.attributes.list", "max");
+  revalidateTag(ORG_ATTRIBUTES_CACHE_TAG, "max");
+}
+
+export async function revalidateRolesList() {
+  revalidateTag(ORG_ROLES_CACHE_TAG, "max");
 }

--- a/apps/web/app/(use-page-wrapper)/settings/organizations/(org-user-only)/members/cache.ts
+++ b/apps/web/app/(use-page-wrapper)/settings/organizations/(org-user-only)/members/cache.ts
@@ -1,0 +1,2 @@
+export const ORG_ATTRIBUTES_CACHE_TAG = "viewer.attributes.list";
+export const ORG_ROLES_CACHE_TAG = "pbac.roles.list";

--- a/apps/web/app/(use-page-wrapper)/settings/organizations/(org-user-only)/members/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/organizations/(org-user-only)/members/page.tsx
@@ -1,6 +1,6 @@
 import { createRouterCaller } from "app/_trpc/context";
 import { _generateMetadata } from "app/_utils";
-import { unstable_cache, cacheLife, cacheTag } from "next/cache";
+import { unstable_cache } from "next/cache";
 import { headers, cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
@@ -48,10 +48,6 @@ const getCachedRoles = unstable_cache(
 );
 
 const Page = async () => {
-  "use cache: private";
-  cacheLife({ stale: 30 });
-  cacheTag(ORG_ATTRIBUTES_CACHE_TAG);
-
   const session = await getServerSession({ req: buildLegacyRequest(await headers(), await cookies()) });
 
   if (!session?.user.id || !session?.user.profile?.organizationId || !session?.user.org) {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -219,6 +219,7 @@ const nextConfig = (phase: string): NextConfig => {
 
   return {
     output: process.env.BUILD_STANDALONE === "true" ? "standalone" : undefined,
+    cacheComponents: true,
     serverExternalPackages: [
       "deasync",
       "http-cookie-agent",

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -217,10 +217,9 @@ const nextConfig = (phase: string): NextConfig => {
     );
   }
 
-  return {
-    output: process.env.BUILD_STANDALONE === "true" ? "standalone" : undefined,
-    cacheComponents: true,
-    serverExternalPackages: [
+    return {
+      output: process.env.BUILD_STANDALONE === "true" ? "standalone" : undefined,
+      serverExternalPackages: [
       "deasync",
       "http-cookie-agent",
       "rest-facade",


### PR DESCRIPTION
PR criada automaticamente.

Source: upstream/perf/teams-page-client-caching


---

<!-- kody-pr-summary:start -->
Refactors the caching strategy across several pages to utilize Next.js's `revalidateTag` for more granular cache invalidation.

Key changes include:
-   **Introduced dedicated cache tag constants**: New `cache.ts` files define string constants for cache tags (e.g., `AVAILABILITY_CACHE_TAG`, `EVENT_TYPES_CACHE_TAG`, `TEAMS_CACHE_TAG`, `API_KEYS_CACHE_TAG`, `ORG_ATTRIBUTES_CACHE_TAG`, `ORG_ROLES_CACHE_TAG`).
-   **Switched to tag-based revalidation**: Server actions now use `revalidateTag` with these new constants instead of `revalidatePath`, allowing for more precise cache invalidation when data changes.
-   **Explicitly assigned cache tags**: `unstable_cache` calls on affected pages now explicitly include these constants in their `tags` option, ensuring that cached data can be targeted for revalidation by tag.

This change improves cache efficiency by allowing specific data segments to be revalidated without invalidating the entire page, affecting the following areas:
-   Availability list
-   Event types list
-   Teams list
-   API keys list
-   Organization attributes and roles lists
<!-- kody-pr-summary:end -->