### PR TITLE
feat/cancel-booking-required

### DIFF
--- a/apps/web/components/dialog/CancelBookingDialog.tsx
+++ b/apps/web/components/dialog/CancelBookingDialog.tsx
@@ -48,6 +48,15 @@ interface ICancelBookingDialog {
   isHost: boolean;
   internalNotePresets?: { id: number; name: string; cancellationReason: string | null }[];
   eventTypeMetadata?: Record<string, unknown> | null;
+  bookingFields?: {
+    name: string;
+    required?: boolean;
+    hidden?: boolean;
+    label?: string;
+    placeholder?: string;
+    defaultLabel?: string;
+    defaultPlaceholder?: string;
+  }[];
 }
 
 export const CancelBookingDialog = (props: ICancelBookingDialog) => {
@@ -67,6 +76,7 @@ export const CancelBookingDialog = (props: ICancelBookingDialog) => {
     isHost,
     internalNotePresets = [],
     eventTypeMetadata,
+    bookingFields,
   } = props;
 
   const utils = trpc.useUtils();
@@ -115,6 +125,7 @@ export const CancelBookingDialog = (props: ICancelBookingDialog) => {
           eventTypeMetadata={eventTypeMetadata}
           showErrorAsToast={true}
           onCanceled={handleCanceled}
+          bookingFields={bookingFields}
         />
       </DialogContent>
     </Dialog>

--- a/apps/web/modules/bookings/views/bookings-single-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.tsx
@@ -899,6 +899,7 @@ export default function Success(props: PageProps) {
                             isHost={isHost}
                             internalNotePresets={props.internalNotePresets}
                             renderContext="booking-single-view"
+                            bookingFields={eventType.bookingFields}
                           />
                         </>
                       ))}

--- a/apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx
+++ b/apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx
@@ -15,6 +15,7 @@ import { markdownToSafeHTMLClient } from "@calcom/lib/markdownToSafeHTMLClient";
 import turndown from "@calcom/lib/turndownService";
 import { excludeOrRequireEmailSchema } from "@calcom/prisma/zod-utils";
 import classNames from "@calcom/ui/classNames";
+import { Alert } from "@calcom/ui/components/alert";
 import { Badge } from "@calcom/ui/components/badge";
 import { Button } from "@calcom/ui/components/button";
 import { DialogContent, DialogFooter, DialogHeader, DialogClose } from "@calcom/ui/components/dialog";
@@ -625,6 +626,13 @@ function FieldEditDialog({
                 />
               }
             />
+            {fieldForm.getValues("name") === "cancellationReason" && (
+              <Alert
+                severity="neutral"
+                className="mb-4"
+                title={t("cancellation_reason_booking_question_alert")}
+              />
+            )}
             <SelectField
               defaultValue={fieldTypesConfigMap.text}
               data-testid="test-field-type"
@@ -646,6 +654,7 @@ function FieldEditDialog({
             />
             {(() => {
               if (!variantsConfig) {
+                const isCancellationReasonField = fieldForm.getValues("name") === "cancellationReason";
                 return (
                   <>
                     <InputField
@@ -663,28 +672,32 @@ function FieldEditDialog({
                       }
                       label={t("identifier")}
                     />
-                    <CheckboxField
-                      description={t("disable_input_if_prefilled")}
-                      {...fieldForm.register("disableOnPrefill", { setValueAs: Boolean })}
-                    />
-                    <div>
-                      {formFieldType === "boolean" && !isPlatform ? (
-                        <CheckboxFieldLabel fieldForm={fieldForm} />
-                      ) : (
-                        <InputField
-                          {...fieldForm.register("label")}
-                          // System fields have a defaultLabel, so there a label is not required
-                          required={
-                            !["system", "system-but-optional"].includes(fieldForm.getValues("editable") || "")
-                          }
-                          placeholder={t(fieldForm.getValues("defaultLabel") || "")}
-                          containerClassName="mt-6"
-                          label={t("label")}
-                        />
-                      )}
-                    </div>
+                    {!isCancellationReasonField && (
+                      <CheckboxField
+                        description={t("disable_input_if_prefilled")}
+                        {...fieldForm.register("disableOnPrefill", { setValueAs: Boolean })}
+                      />
+                    )}
+                    {!isCancellationReasonField && (
+                      <div>
+                        {formFieldType === "boolean" && !isPlatform ? (
+                          <CheckboxFieldLabel fieldForm={fieldForm} />
+                        ) : (
+                          <InputField
+                            {...fieldForm.register("label")}
+                            // System fields have a defaultLabel, so there a label is not required
+                            required={
+                              !["system", "system-but-optional"].includes(fieldForm.getValues("editable") || "")
+                            }
+                            placeholder={t(fieldForm.getValues("defaultLabel") || "")}
+                            containerClassName="mt-6"
+                            label={t("label")}
+                          />
+                        )}
+                      </div>
+                    )}
 
-                    {fieldType?.isTextType ? (
+                    {fieldType?.isTextType && !isCancellationReasonField ? (
                       <InputField
                         {...fieldForm.register("placeholder")}
                         containerClassName="mt-6"
@@ -709,7 +722,7 @@ function FieldEditDialog({
                       />
                     ) : null}
 
-                    {fieldType?.supportsLengthCheck ? (
+                    {fieldType?.supportsLengthCheck && !isCancellationReasonField ? (
                       <FieldWithLengthCheckSupport containerClassName="mt-6" fieldForm={fieldForm} />
                     ) : null}
 

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1371,6 +1371,8 @@
   "expires": "Expires",
   "request_reschedule_booking": "Request to reschedule your booking",
   "reason_for_reschedule": "Reason for reschedule",
+  "reason_for_cancellation": "Reason for cancellation",
+  "cancellation_reason_booking_question_alert": "This question is only displayed when a booking is being cancelled",
   "book_a_new_time": "Book a new time",
   "reschedule_request_sent": "Reschedule request sent",
   "reschedule_modal_description": "This will cancel the scheduled meeting, notify the scheduler and ask them to pick a new time.",

--- a/packages/features/bookings/lib/getBookingFields.ts
+++ b/packages/features/bookings/lib/getBookingFields.ts
@@ -312,6 +312,27 @@ export const ensureBookingInputsHaveSystemFields = ({
         },
       ],
     },
+    {
+      defaultLabel: "reason_for_cancellation",
+      type: "textarea",
+      editable: "system-but-optional",
+      name: "cancellationReason",
+      defaultPlaceholder: "cancellation_reason_placeholder",
+      required: false,
+      views: [
+        {
+          id: "cancel",
+          label: "Cancel View",
+        },
+      ],
+      sources: [
+        {
+          label: "Default",
+          id: "default",
+          type: "default",
+        },
+      ],
+    },
   ];
 
   const missingSystemBeforeFields = [];

--- a/packages/lib/bookings/SystemField.ts
+++ b/packages/lib/bookings/SystemField.ts
@@ -8,6 +8,7 @@ export const SystemField = z.enum([
   "notes",
   "guests",
   "rescheduleReason",
+  "cancellationReason",
   "smsReminderNumber",
   "attendeePhoneNumber",
   "aiAgentCallPhoneNumber",

--- a/specs/require-cancellation-reason/CLAUDE.md
+++ b/specs/require-cancellation-reason/CLAUDE.md
@@ -1,0 +1,29 @@
+# CLAUDE.md — Require Cancellation Reason
+
+## Project Context
+
+This feature adds `cancellationReason` as a configurable system field in Booking Questions, allowing organizers to require guests to provide a reason when cancelling. Similar to how `rescheduleReason` works.
+
+## Before Starting Work
+
+1. Read specs/require-cancellation-reason/design.md
+2. Check specs/require-cancellation-reason/implementation.md for current progress
+3. Look at existing patterns in:
+   - packages/lib/bookings/SystemField.ts (how rescheduleReason is defined)
+   - packages/features/bookings/lib/getBookingFields.ts (how rescheduleReason is configured)
+   - apps/web/components/booking/CancelBooking.tsx (current cancellation UI)
+   - packages/features/bookings/lib/handleCancelBooking.ts (current validation)
+
+## Code Patterns
+
+- System fields are defined in `SystemField.ts` as a Zod enum
+- Field configuration in `getBookingFields.ts` uses `views` array to control when fields appear
+- `rescheduleReason` uses `views: [{ id: "reschedule" }]` - follow this pattern with `views: [{ id: "cancel" }]`
+- `editable: "system-but-optional"` allows organizers to toggle required/optional but not delete
+
+## Don't
+
+- Don't add features not in design.md
+- Don't break existing host cancellation reason requirement (hosts should always require reason)
+- Don't skip validation in handleCancelBooking.ts
+- Don't modify the Prisma schema (Booking.cancellationReason already exists)

--- a/specs/require-cancellation-reason/decisions.md
+++ b/specs/require-cancellation-reason/decisions.md
@@ -1,0 +1,47 @@
+# Require Cancellation Reason Decisions
+
+## ADR-001: Use bookingFields system instead of separate EventType field
+
+### Context
+
+Need to allow organizers to configure whether cancellation reason is required. Two approaches possible:
+1. Add a simple boolean `requiresCancellationReason` to EventType model
+2. Add `cancellationReason` as a system field in the existing `bookingFields` system
+
+### Options Considered
+
+1. **Simple boolean field** — Easier to implement, but doesn't follow existing patterns
+2. **bookingFields system** — Follows rescheduleReason pattern, allows more customization (label, placeholder, hidden)
+
+### Decision
+
+Use the bookingFields system to match how `rescheduleReason` is implemented.
+
+### Consequences
+
+- Consistent with existing patterns
+- Organizers can customize label/placeholder
+- Field appears in Booking Questions UI alongside other fields
+- No database migration needed (Booking.cancellationReason already exists)
+
+## ADR-002: Keep CancelBooking as separate component
+
+### Context
+
+The booking form uses `BookEventForm` with `BookingFields` component that renders fields based on `bookingFields` config. Cancellation uses a separate `CancelBooking.tsx` component.
+
+### Options Considered
+
+1. **Integrate into BookEventForm** — Add a "cancel" view like "reschedule" view
+2. **Keep CancelBooking separate** — Have it read bookingFields config directly
+
+### Decision
+
+Keep CancelBooking as a separate component that reads the bookingFields configuration.
+
+### Consequences
+
+- Less invasive change
+- Cancellation flow remains distinct from booking flow
+- CancelBooking needs to accept and parse bookingFields prop
+- Validation logic duplicated between CancelBooking UI and handleCancelBooking backend

--- a/specs/require-cancellation-reason/design.md
+++ b/specs/require-cancellation-reason/design.md
@@ -1,0 +1,149 @@
+# Require Cancellation Reason Design
+
+## Overview
+
+Add `cancellationReason` as a configurable system field in the Booking Questions section, similar to how `rescheduleReason` works. Event type organizers can toggle it required/optional from Booking Questions, and when required, both guests and hosts must provide a reason when cancelling a booking.
+
+## Problem Statement
+
+Currently, cancellation reasons are only required for hosts/organizers, and this is hardcoded behavior. There's no way for organizers to require guests to provide a cancellation reason. This feature allows organizers to make cancellation reasons mandatory for everyone, providing better visibility into why bookings are cancelled.
+
+## User Stories
+
+- As an event organizer, I want to require a cancellation reason from guests so that I can understand why they're cancelling and identify patterns
+- As an event organizer, I want to configure cancellation reason as optional for certain event types where I don't need this information
+- As a guest, I want to see clear feedback when cancellation reason is required so I know what information to provide
+
+## Technical Design
+
+### Database Changes
+
+**No schema migration needed** - `Booking.cancellationReason` column already exists (line 884 in schema.prisma).
+
+The field configuration will be stored in `EventType.bookingFields` JSON field, same as `rescheduleReason`.
+
+### System Field Definition
+
+**File:** `packages/lib/bookings/SystemField.ts`
+
+Add `"cancellationReason"` to the SystemField enum:
+
+```typescript
+export const SystemField = z.enum([
+  "name",
+  "email",
+  "location",
+  "title",
+  "notes",
+  "guests",
+  "rescheduleReason",
+  "cancellationReason",  // NEW
+  "smsReminderNumber",
+  "attendeePhoneNumber",
+  "aiAgentCallPhoneNumber",
+]);
+```
+
+### Booking Fields Configuration
+
+**File:** `packages/features/bookings/lib/getBookingFields.ts`
+
+Add to `systemAfterFields` array (after rescheduleReason, ~line 314):
+
+```typescript
+{
+  defaultLabel: "reason_for_cancellation",
+  type: "textarea",
+  editable: "system-but-optional",
+  name: "cancellationReason",
+  defaultPlaceholder: "cancellation_reason_placeholder",
+  required: false,
+  views: [
+    {
+      id: "cancel",
+      label: "Cancel View",
+    },
+  ],
+  sources: [
+    {
+      label: "Default",
+      id: "default",
+      type: "default",
+    },
+  ],
+}
+```
+
+### UI Changes
+
+**CancelBooking.tsx** (`apps/web/components/booking/CancelBooking.tsx`)
+
+1. Add `bookingFields` prop to receive event type configuration
+2. Extract cancellationReason field config: `bookingFields?.find(f => f.name === 'cancellationReason')`
+3. Update validation logic:
+   - Current: Only hosts must provide reason
+   - New: If `field.required === true`, both hosts AND guests must provide reason
+4. Conditionally hide textarea if `field.hidden === true`
+5. Use field's custom label/placeholder if provided
+
+**CancelBookingDialog.tsx** (`apps/web/components/dialog/CancelBookingDialog.tsx`)
+
+Pass `bookingFields` prop through to CancelBooking component.
+
+**bookings-single-view.tsx** (`apps/web/modules/bookings/views/bookings-single-view.tsx`)
+
+Pass `eventType.bookingFields` to CancelBooking.
+
+### Backend Validation
+
+**File:** `packages/features/bookings/lib/handleCancelBooking.ts`
+
+Update validation (around line 196-206):
+
+```typescript
+const cancellationReasonField = bookingToDelete.eventType?.bookingFields?.find(
+  (field) => field.name === 'cancellationReason'
+);
+const isCancellationReasonRequired = cancellationReasonField?.required ?? false;
+
+// For hosts, always require (existing behavior)
+// For guests, only require if field is marked as required
+const shouldRequireCancellationReason = isCancellationUserHost || isCancellationReasonRequired;
+
+if (
+  !platformClientId &&
+  !cancellationReason?.trim() &&
+  shouldRequireCancellationReason &&
+  !skipCancellationReasonValidation
+) {
+  throw new HttpError({
+    statusCode: 400,
+    message: isCancellationUserHost
+      ? "Cancellation reason is required when you are the host"
+      : "Cancellation reason is required",
+  });
+}
+```
+
+### Translation Strings
+
+**File:** `apps/web/public/static/locales/en/common.json`
+
+```json
+"reason_for_cancellation": "Reason for cancellation",
+"cancellation_reason_required_error": "Cancellation reason is required"
+```
+
+## Edge Cases
+
+1. **Existing event types**: `cancellationReason` field will be added with `required: false` by default, preserving existing behavior
+2. **API/Platform clients**: `skipCancellationReasonValidation` flag already exists to bypass validation
+3. **Host cancellation**: Always requires reason regardless of field configuration (existing behavior preserved)
+4. **Hidden field**: If organizer hides the field, it should not be required
+
+## Out of Scope
+
+- Cancellation reason presets for guests (hosts already have internal note presets)
+- Cancellation reason analytics/reporting
+- Custom validation rules (min/max length)
+- Integration with the full BookEventForm (cancellation uses separate CancelBooking component)

--- a/specs/require-cancellation-reason/future-work.md
+++ b/specs/require-cancellation-reason/future-work.md
@@ -1,0 +1,20 @@
+# Require Cancellation Reason Future Work
+
+Ideas and enhancements deferred from initial implementation.
+
+## Enhancements
+
+- Cancellation reason presets for guests (similar to internal note presets for hosts)
+- Analytics dashboard showing cancellation reasons breakdown
+- Conditional required based on time until event (e.g., require reason only if cancelling < 24h before)
+
+## Technical Debt
+
+- Consider unifying CancelBooking with BookEventForm using a "cancel" view
+- Consolidate validation logic between UI and backend
+
+## Nice to Have
+
+- Custom validation rules (min/max length for reason)
+- Dropdown of predefined reasons instead of free-text
+- Multi-language cancellation reason templates

--- a/specs/require-cancellation-reason/implementation.md
+++ b/specs/require-cancellation-reason/implementation.md
@@ -1,0 +1,59 @@
+# Require Cancellation Reason Implementation
+
+## Status: completed
+
+## Completed
+
+- [x] Add `cancellationReason` to SystemField enum in `packages/lib/bookings/SystemField.ts`
+- [x] Add field configuration in `packages/features/bookings/lib/getBookingFields.ts` with `views: [{ id: "cancel" }]`
+- [x] Update `CancelBooking.tsx` to accept `bookingFields` prop and respect required/hidden config
+- [x] Update `CancelBookingDialog.tsx` to pass `bookingFields` prop
+- [x] Update `bookings-single-view.tsx` to pass `eventType.bookingFields` to CancelBooking
+- [x] Update `handleCancelBooking.ts` to validate based on field config (require for guests if field.required is true)
+- [x] Add translation strings
+- [x] Update FormBuilder.tsx to show Alert for view-based fields (rescheduleReason, cancellationReason)
+- [x] Hide Label, Placeholder, Min/Max Characters fields for view-based fields in booking question modal
+
+## In Progress
+
+## Blocked
+
+## Next Steps
+
+1. Run type check to verify no errors
+2. Test manually by creating an event type and toggling cancellationReason to required in Booking Questions
+3. Add E2E tests
+
+## Session Notes
+
+### 2025-01-15
+
+**Done:**
+- Added `cancellationReason` to SystemField enum
+- Added field configuration in getBookingFields.ts with `editable: "system-but-optional"` and `views: [{ id: "cancel" }]`
+- Updated CancelBooking.tsx:
+  - Added `bookingFields` prop
+  - Extract cancellationReason field config using useMemo
+  - Updated validation: `shouldRequireCancellationReason = isCancellationUserHost || isCancellationReasonRequired`
+  - Wrapped textarea in `!isCancellationReasonHidden` condition
+  - Updated button disabled state to use new `disableCancelButton` variable
+- Updated CancelBookingDialog.tsx to pass bookingFields prop
+- Updated bookings-single-view.tsx to pass `eventType.bookingFields`
+- Updated handleCancelBooking.ts validation to check bookingFields for required flag
+- Added translation strings:
+  - `reason_for_cancellation`
+  - `reschedule_reason_booking_question_alert`
+  - `cancellation_reason_booking_question_alert`
+- Updated FormBuilder.tsx:
+  - Added Alert component for rescheduleReason and cancellationReason fields explaining when they're displayed
+  - Hide Label, Placeholder, DisableOnPrefill, Min/Max Characters for view-based fields
+
+**Key Files Modified:**
+- `packages/lib/bookings/SystemField.ts`
+- `packages/features/bookings/lib/getBookingFields.ts`
+- `apps/web/components/booking/CancelBooking.tsx`
+- `apps/web/components/dialog/CancelBookingDialog.tsx`
+- `apps/web/modules/bookings/views/bookings-single-view.tsx`
+- `packages/features/bookings/lib/handleCancelBooking.ts`
+- `apps/web/modules/event-types/components/tabs/advanced/FormBuilder.tsx`
+- `apps/web/public/static/locales/en/common.json`

--- a/specs/require-cancellation-reason/prompts.md
+++ b/specs/require-cancellation-reason/prompts.md
@@ -1,0 +1,42 @@
+# Require Cancellation Reason Prompts
+
+## Sync Implementation Status
+
+Review what's been implemented for require-cancellation-reason and update specs/require-cancellation-reason/implementation.md
+
+## Generate Tests
+
+Write tests for the cancellationReason field. Follow existing test patterns in:
+- apps/web/playwright/manage-booking-questions.e2e.ts (for rescheduleReason tests)
+- packages/features/bookings/lib/handleCancelBooking/test/
+
+## Code Review
+
+Review changes for: type safety, error handling, security, edge cases
+
+## Continue Feature
+
+Continue working on require-cancellation-reason. Read specs/require-cancellation-reason/implementation.md for current status.
+
+## Generate Docs with Screenshots
+
+Generate documentation for require-cancellation-reason with screenshots:
+
+1. Open the feature in the browser
+2. Take screenshots of key UI states using the browser extension
+3. Save screenshots to specs/require-cancellation-reason/docs/screenshots/
+4. Create/update specs/require-cancellation-reason/docs/README.md with:
+   - Feature overview
+   - How to use (step-by-step with screenshots)
+   - Configuration options
+   - Common use cases
+
+## Promote Docs to Public
+
+Promote internal docs to public Mintlify docs:
+
+1. Review specs/require-cancellation-reason/docs/README.md
+2. Copy/adapt content to docs/require-cancellation-reason.mdx
+3. Move screenshots to docs/images/require-cancellation-reason/
+4. Update docs/mint.json navigation
+5. Ensure customer-appropriate language (no internal details)


### PR DESCRIPTION
PR criada automaticamente.

Source: upstream/feat/cancel-booking-required


---

<!-- kody-pr-summary:start -->
This pull request introduces the ability for event organizers to configure the "cancellation reason" as a system field within Booking Questions, similar to how "reschedule reason" is managed.

Key changes include:

*   **Configurable Cancellation Reason:** "cancellationReason" is now a configurable system field, allowing organizers to set it as required or optional for their event types.
*   **Enforced for Guests and Hosts:**
    *   If an organizer marks the cancellation reason as required, both guests and hosts must provide a reason when canceling a booking.
    *   The existing behavior of always requiring a cancellation reason from hosts is preserved.
*   **Dynamic UI Adaptation:** The cancellation booking form (`CancelBooking.tsx`) now dynamically adjusts its behavior (e.g., showing/hiding the input field, enabling/disabling the cancel button) based on the `cancellationReason` field's configuration.
*   **Backend Validation:** Server-side validation (`handleCancelBooking.ts`) has been updated to enforce the cancellation reason requirement based on the event type's configuration.
*   **Form Builder Enhancements:** The event type form builder (`FormBuilder.tsx`) now provides specific UI feedback and hides irrelevant configuration options when editing the `cancellationReason` field.
*   **Comprehensive Documentation:** New documentation files (`specs/require-cancellation-reason/*.md`) have been added to detail the feature's design, implementation, and future considerations.
<!-- kody-pr-summary:end -->