### PR TITLE
feat(companion): add EU region support for companion apps

### DIFF
--- a/companion/components/event-type-detail/tabs/AdvancedTab.tsx
+++ b/companion/components/event-type-detail/tabs/AdvancedTab.tsx
@@ -19,8 +19,11 @@ import {
   View,
 } from "react-native";
 
+import { getAppBaseUrl } from "@/config/region";
 import { showInfoAlert } from "@/utils/alerts";
 import { openInAppBrowser } from "@/utils/browser";
+import { getStoredRegion } from "@/utils/storage";
+
 import { IOSPickerTrigger } from "./IOSPickerTrigger";
 
 // Interface language options matching API V2 enum
@@ -421,7 +424,11 @@ export function AdvancedTab(props: AdvancedTabProps) {
             isLast
             title="Locked Timezone"
             value={props.lockedTimezone || "Europe/London"}
-            onPress={() => openInAppBrowser("https://app.cal.com/event-types", "Select Timezone")}
+            onPress={async () => {
+              const region = await getStoredRegion();
+              const baseUrl = getAppBaseUrl(region);
+              openInAppBrowser(`${baseUrl}/event-types`, "Select Timezone");
+            }}
           />
         </SettingsGroup>
       ) : null}

--- a/companion/config/index.ts
+++ b/companion/config/index.ts
@@ -6,7 +6,22 @@
  * @example
  * ```tsx
  * import { CACHE_CONFIG, queryKeys } from '../config';
+ * import { getAppBaseUrl, getApiBaseUrl, type Region } from '../config';
  * ```
  */
 
 export { CACHE_CONFIG, queryKeys } from "./cache.config";
+export {
+  type Region,
+  DEFAULT_REGION,
+  REGION_STORAGE_KEY,
+  REGION_OPTIONS,
+  getAppBaseUrl,
+  getApiBaseUrl,
+  getAssetUrl,
+  getSignupUrl,
+  getBookingUrl,
+  getRescheduleUrl,
+  isValidRegion,
+  getAppHostnames,
+} from "./region";

--- a/companion/config/region.ts
+++ b/companion/config/region.ts
@@ -1,0 +1,67 @@
+/**
+ * Region Configuration for Cal.com Companion App
+ *
+ * This module provides centralized configuration for region-aware URLs.
+ * Supports US (default) and EU regions with different API and app endpoints.
+ */
+
+export type Region = "US" | "EU";
+
+export const DEFAULT_REGION: Region = "US";
+
+export const REGION_STORAGE_KEY = "cal_region";
+
+interface RegionConfig {
+  appBaseUrl: string;
+  apiBaseUrl: string;
+}
+
+const REGION_CONFIGS: Record<Region, RegionConfig> = {
+  US: {
+    appBaseUrl: "https://app.cal.com",
+    apiBaseUrl: "https://api.cal.com/v2",
+  },
+  EU: {
+    appBaseUrl: "https://app.cal.eu",
+    apiBaseUrl: "https://api.cal.eu/v2",
+  },
+};
+
+export function getAppBaseUrl(region: Region): string {
+  return REGION_CONFIGS[region].appBaseUrl;
+}
+
+export function getApiBaseUrl(region: Region): string {
+  return REGION_CONFIGS[region].apiBaseUrl;
+}
+
+export function getAssetUrl(region: Region, path: string): string {
+  const baseUrl = getAppBaseUrl(region);
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${baseUrl}${normalizedPath}`;
+}
+
+export function getSignupUrl(region: Region): string {
+  return `${getAppBaseUrl(region)}/signup`;
+}
+
+export function getBookingUrl(region: Region, bookingUid: string): string {
+  return `${getAppBaseUrl(region)}/booking/${bookingUid}`;
+}
+
+export function getRescheduleUrl(region: Region, rescheduleUid: string): string {
+  return `${getAppBaseUrl(region)}/reschedule/${rescheduleUid}`;
+}
+
+export function isValidRegion(value: string): value is Region {
+  return value === "US" || value === "EU";
+}
+
+export const REGION_OPTIONS: Array<{ value: Region; label: string }> = [
+  { value: "US", label: "United States" },
+  { value: "EU", label: "European Union" },
+];
+
+export function getAppHostnames(): string[] {
+  return Object.values(REGION_CONFIGS).map((config) => new URL(config.appBaseUrl).hostname);
+}

--- a/companion/hooks/useBookingActionModals.ts
+++ b/companion/hooks/useBookingActionModals.ts
@@ -8,7 +8,9 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
 import { Alert, Linking } from "react-native";
+
 import { queryKeys } from "@/config/cache.config";
+import { getBookingUrl } from "@/config/region";
 import { type Booking, CalComAPIService } from "@/services/calcom";
 import type {
   AddGuestInput,
@@ -16,6 +18,7 @@ import type {
   ConferencingSession,
 } from "@/services/types/bookings.types";
 import { showErrorAlert, showSuccessAlert } from "@/utils/alerts";
+import { getStoredRegion } from "@/utils/storage";
 
 interface UseBookingActionModalsReturn {
   // Selected booking for actions
@@ -277,10 +280,9 @@ export function useBookingActionModals(): UseBookingActionModalsReturn {
   // Request Reschedule (deep link to web)
   // ============================================================================
 
-  const handleRequestReschedule = useCallback((booking: Booking) => {
-    // Request reschedule is a server-driven operation that requires the web app
-    // We deep link to the booking detail page where the user can trigger it
-    const webUrl = `https://app.cal.com/booking/${booking.uid}`;
+  const handleRequestReschedule = useCallback(async (booking: Booking) => {
+    const region = await getStoredRegion();
+    const webUrl = getBookingUrl(region, booking.uid);
 
     Alert.alert(
       "Request Reschedule",

--- a/companion/services/calcom.ts
+++ b/companion/services/calcom.ts
@@ -1,3 +1,4 @@
+import { type Region, DEFAULT_REGION, getApiBaseUrl } from "@/config/region";
 import { fetchWithTimeout } from "@/utils/network";
 import { safeLogError, safeLogInfo } from "@/utils/safeLogger";
 
@@ -31,7 +32,15 @@ import type {
   Webhook,
 } from "./types";
 
-const API_BASE_URL = "https://api.cal.com/v2";
+let currentRegion: Region = DEFAULT_REGION;
+
+function getApiUrl(): string {
+  return getApiBaseUrl(currentRegion);
+}
+
+function setApiRegion(region: Region): void {
+  currentRegion = region;
+}
 
 const REQUEST_TIMEOUT_MS = 30000;
 
@@ -327,7 +336,7 @@ function clearUserProfile(): void {
 // Test function for bookings API specifically
 async function testRawBookingsAPI(): Promise<void> {
   try {
-    const url = `${API_BASE_URL}/bookings?status=upcoming&status=unconfirmed&limit=50`;
+    const url = `${getApiUrl()}/bookings?status=upcoming&status=unconfirmed&limit=50`;
 
     const response = await fetchWithTimeout(
       url,
@@ -364,7 +373,7 @@ async function makeRequest<T>(
   apiVersion: string = "2024-08-13",
   isRetry: boolean = false
 ): Promise<T> {
-  const url = `${API_BASE_URL}${endpoint}`;
+  const url = `${getApiUrl()}${endpoint}`;
 
   const response = await fetchWithTimeout(
     url,
@@ -1667,6 +1676,7 @@ async function getUsername(): Promise<string> {
 
 // Export as object to satisfy noStaticOnlyClass rule
 export const CalComAPIService = {
+  setApiRegion,
   setAccessToken,
   setRefreshTokenFunction,
   clearAuth,

--- a/companion/utils/browser.ts
+++ b/companion/utils/browser.ts
@@ -8,6 +8,8 @@
 import * as WebBrowser from "expo-web-browser";
 import { Platform } from "react-native";
 
+import { getAppHostnames } from "@/config/region";
+
 import { showErrorAlert } from "./alerts";
 
 /**
@@ -21,12 +23,12 @@ export interface BrowserOptions {
 }
 
 /**
- * Appends ?standalone=true to app.cal.com URLs on iOS.
+ * Appends ?standalone=true to Cal.com app URLs on iOS.
  * This hides navigation elements when pages are opened in the in-app browser,
  * which is required for Apple App Store compliance.
  *
  * @param url - The URL to process
- * @returns The URL with standalone=true appended if it's an app.cal.com URL on iOS
+ * @returns The URL with standalone=true appended if it's a Cal.com app URL on iOS
  */
 const appendStandaloneParam = (url: string): string => {
   // Only apply to iOS
@@ -37,8 +39,9 @@ const appendStandaloneParam = (url: string): string => {
   try {
     const urlObj = new URL(url);
 
-    // Only apply to app.cal.com URLs
-    if (urlObj.hostname !== "app.cal.com") {
+    // Only apply to Cal.com app URLs (both US and EU regions)
+    const calHostnames = getAppHostnames();
+    if (!calHostnames.includes(urlObj.hostname)) {
       return url;
     }
 

--- a/companion/utils/deep-links.ts
+++ b/companion/utils/deep-links.ts
@@ -9,18 +9,16 @@ import * as Linking from "expo-linking";
 import * as WebBrowser from "expo-web-browser";
 import { Alert, Platform } from "react-native";
 
+import { getAppBaseUrl, getAppHostnames } from "@/config/region";
 import { showErrorAlert } from "@/utils/alerts";
-
-// Default Cal.com web URL - can be overridden for self-hosted instances
-const DEFAULT_CAL_WEB_URL = "https://app.cal.com";
+import { getStoredRegion } from "@/utils/storage";
 
 /**
- * Get the Cal.com web URL from environment or use default
+ * Get the Cal.com web URL based on stored region
  */
-function getCalWebUrl(): string {
-  // In a real implementation, this would read from environment config
-  // For now, use the default Cal.com URL
-  return DEFAULT_CAL_WEB_URL;
+async function getCalWebUrl(): Promise<string> {
+  const region = await getStoredRegion();
+  return getAppBaseUrl(region);
 }
 
 /**
@@ -40,8 +38,9 @@ function appendStandaloneParam(url: string): string {
   try {
     const urlObj = new URL(url);
 
-    // Only apply to app.cal.com URLs
-    if (urlObj.hostname !== "app.cal.com") {
+    // Only apply to Cal.com app URLs (both US and EU regions)
+    const calHostnames = getAppHostnames();
+    if (!calHostnames.includes(urlObj.hostname)) {
       return url;
     }
 
@@ -65,7 +64,7 @@ function appendStandaloneParam(url: string): string {
  * @param bookingUid - The unique identifier of the booking
  */
 export async function openBookingInWeb(bookingUid: string): Promise<void> {
-  const webUrl = getCalWebUrl();
+  const webUrl = await getCalWebUrl();
   const url = appendStandaloneParam(`${webUrl}/booking/${bookingUid}`);
 
   try {
@@ -121,7 +120,7 @@ export async function openReschedulePage(
   bookingUid: string,
   rescheduleUid?: string
 ): Promise<void> {
-  const webUrl = getCalWebUrl();
+  const webUrl = await getCalWebUrl();
   const url = appendStandaloneParam(
     rescheduleUid ? `${webUrl}/reschedule/${rescheduleUid}` : `${webUrl}/booking/${bookingUid}`
   );
@@ -147,7 +146,7 @@ export async function openReschedulePage(
  * @param bookingUid - The unique identifier of the booking
  */
 export async function openCancelBookingInWeb(bookingUid: string): Promise<void> {
-  const webUrl = getCalWebUrl();
+  const webUrl = await getCalWebUrl();
   const url = appendStandaloneParam(`${webUrl}/booking/${bookingUid}`);
 
   try {

--- a/companion/utils/storage.ts
+++ b/companion/utils/storage.ts
@@ -16,6 +16,8 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as SecureStore from "expo-secure-store";
 import { Platform } from "react-native";
 
+import { type Region, DEFAULT_REGION, REGION_STORAGE_KEY, isValidRegion } from "@/config/region";
+
 /**
  * Check if chrome.storage is available (browser extension context)
  */
@@ -181,3 +183,23 @@ export const generalStorage: StorageAdapter = {
     return AsyncStorage.removeItem(key);
   },
 };
+
+export async function getStoredRegion(): Promise<Region> {
+  try {
+    const stored = await generalStorage.getItem(REGION_STORAGE_KEY);
+    if (stored && isValidRegion(stored)) {
+      return stored;
+    }
+  } catch {
+    // Fall through to default
+  }
+  return DEFAULT_REGION;
+}
+
+export async function setStoredRegion(region: Region): Promise<void> {
+  await generalStorage.setItem(REGION_STORAGE_KEY, region);
+}
+
+export async function clearStoredRegion(): Promise<void> {
+  await generalStorage.removeItem(REGION_STORAGE_KEY);
+}

--- a/companion/wxt.config.ts
+++ b/companion/wxt.config.ts
@@ -72,6 +72,8 @@ export default defineConfig({
       "https://companion.cal.com/*",
       "https://api.cal.com/*",
       "https://app.cal.com/*",
+      "https://api.cal.eu/*",
+      "https://app.cal.eu/*",
       "https://mail.google.com/*",
       "https://calendar.google.com/*",
       // Include localhost permission for dev builds (needed for iframe to load)


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This PR adds EU data region support to the Cal.com Companion apps by making authentication, API calls, and web/deep-link navigation region-aware.

### Key user-facing changes
- **Region selection on login:** The Companion login screen now includes a **“Data region”** dropdown (United States / European Union). The selected region is used for:
  - **OAuth login** (auth flow targets the region’s Cal.com app domain)
  - **Sign up link** (opens the region-specific signup page)

- **Region is persisted and reused:** The selected region is **stored locally** and loaded on startup to ensure subsequent sessions use the same region automatically. On **logout**, the stored region is cleared so the user must re-select on next login.

### Region-aware routing across the app
- Introduces a centralized **region configuration module** (`config/region.ts`) defining US/EU app and API base URLs and helpers for generating:
  - App base URLs
  - API base URLs
  - Signup, booking, and reschedule URLs
  - Supported hostnames (used for in-app browser behavior)

- Updates various in-app flows to open the **correct regional web pages**, including:
  - Booking pages used for “Request Reschedule”
  - Event Types page access from the Advanced settings tab
  - Deep-link utilities that open booking/reschedule/cancel pages now resolve the base URL from the stored region

### API and extension support
- **Mobile API service** now routes requests to the correct regional API base URL via a settable “current region”.
- **Browser extension background logic** now reads the stored region and uses the matching API base URL for operations like token validation, fetching event types, and booking actions.
- Extension permissions are updated to allow access to **`app.cal.eu`** and **`api.cal.eu`** in addition to the existing `.com` endpoints.

### iOS in-app browser compliance
- The logic that appends `?standalone=true` on iOS now applies to **both `app.cal.com` and `app.cal.eu`** (instead of only `app.cal.com`).
<!-- kody-pr-summary:end -->